### PR TITLE
Log better error messages for streaming reply from ollama /v1/chat/completions API

### DIFF
--- a/ovos_solver_openai_persona/engines.py
+++ b/ovos_solver_openai_persona/engines.py
@@ -146,6 +146,9 @@ class OpenAIChatCompletionsSolver(QuestionSolver):
             if chunk:
                 chunk = chunk.decode("utf-8")
                 chunk = json.loads(chunk.split("data: ", 1)[-1])
+                if chunk["error"] and chunk["error"]["message"]:
+                    LOG.error("API returned an error: " + chunk["error"]["message"])
+                    break
                 if chunk["choices"][0].get("finish_reason"):
                     break
                 if "content" not in chunk["choices"][0]["delta"]:

--- a/ovos_solver_openai_persona/engines.py
+++ b/ovos_solver_openai_persona/engines.py
@@ -146,7 +146,7 @@ class OpenAIChatCompletionsSolver(QuestionSolver):
             if chunk:
                 chunk = chunk.decode("utf-8")
                 chunk = json.loads(chunk.split("data: ", 1)[-1])
-                if chunk["error"] and chunk["error"]["message"]:
+                if "error" in chunk and "message" in chunk["error"]:
                     LOG.error("API returned an error: " + chunk["error"]["message"])
                     break
                 if chunk["choices"][0].get("finish_reason"):


### PR DESCRIPTION
I was getting a cryptic log message `ERROR - choices` in my logs and couldn't figure it out. Turns out ollama was returning errors in a specific format; by adding a few lines here we get a more useful error message `ERROR - API returned an error: model "gpt-3.5-turbo" not found, try pulling it first`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- end of auto-generated comment: release notes by coderabbit.ai -->